### PR TITLE
force meta charset encoding to utf-8

### DIFF
--- a/src/-lib/html-normalizer.js
+++ b/src/-lib/html-normalizer.js
@@ -33,7 +33,14 @@ export default class HTMLNormalizer {
   }
   
   _createDocument(html) {
-    return new DOMParser().parseFromString(html, 'text/html');
+    let document = new DOMParser().parseFromString(html, 'text/html');
+
+    //force charset encoding to utf-8, necessary for some non-english sites
+    let metaTag = document.querySelector('meta');
+    if (metaTag) {
+      metaTag.setAttribute('charset', 'utf-8')
+    }
+    return document;
   }
   
   _generateBaseURL(resourceURL) {

--- a/test/-lib/html-normalizer-test.js
+++ b/test/-lib/html-normalizer-test.js
@@ -261,6 +261,11 @@ module('HTMLNormalizer', () => {
 
         assert.equal(result, 'https://www.movableink.com/somewhere/else/#my-fragment');
       });
+      
+      test('it changes charset encoding to utf-8', (assert) => {
+        const normalizer = new HTMLNormalizer('<html><head><meta charset="euc-jp"></head></html>', 'https://www.rakuten.co.jp');
+        assert.equal(normalizer.document.head.firstChild.getAttribute('charset'), 'utf-8' );
+      });
     });
   });
 });


### PR DESCRIPTION
Some Japanese sites were not rendering properly in the website preview iframe because the original site did not use utf-8 encoding.  This should fix the issue.