### PR TITLE
prevent double encoding in Webkit version

### DIFF
--- a/src/-lib/html-normalizer.js
+++ b/src/-lib/html-normalizer.js
@@ -20,9 +20,9 @@ export default class HTMLNormalizer {
     const url = new URL(this.baseURL); // Copy the URL.
     const { pathname, hash, search } = extractPathParts(providedPath);
 
-    url.pathname = reconcilePaths(url.pathname, pathname);
-    url.search = search;
-    url.hash = hash;
+    url.pathname = decodeURI(reconcilePaths(url.pathname, pathname));
+    url.search = decodeURI(search);
+    url.hash = decodeURI(hash);
 
     return url.toString();
   }
@@ -49,7 +49,7 @@ export default class HTMLNormalizer {
 
       // If the `base` happens to not end in a trailing slash, then we
       // remove the last segment of that path to compute the "base"
-      url.pathname = pathDir(url.pathname);
+      url.pathname = decodeURI(pathDir(url.pathname));
     }
 
     // Remove the fragment and search, if present
@@ -58,7 +58,7 @@ export default class HTMLNormalizer {
 
     // Add the newly resolved path.
     if (docBase) {
-      url.pathname = pathDir(reconcilePaths(url.pathname, docBase));
+      url.pathname = decodeURI(pathDir(reconcilePaths(url.pathname, docBase)));
     }
 
     return url;

--- a/test/-lib/html-normalizer-test.js
+++ b/test/-lib/html-normalizer-test.js
@@ -333,5 +333,34 @@ module('HTMLNormalizer', () => {
         );
       });
     });
+
+    module('special characters', () => {
+      test('it handles paths with spaces in it', assert => {
+        const normalizer = new HTMLNormalizer('');
+
+        const url = 'https://www.not-here.com/somewhere/ else';
+        const result = normalizer.absolutizePath(url);
+
+        assert.equal(result, url);
+      });
+
+      test('it handles already encoded URLs with spaces', assert => {
+        const normalizer = new HTMLNormalizer('');
+
+        const url = 'https://www.not-here.com/somewhere/%20else';
+        const result = normalizer.absolutizePath(url);
+
+        assert.equal(result, url);
+      });
+
+      test('it handles already encoded URLs with spaces', assert => {
+        const normalizer = new HTMLNormalizer('');
+
+        const url = 'https://www.not-here.com/ш?x=л#ы';
+        const result = normalizer.absolutizePath(url);
+
+        assert.equal(result, url);
+      });
+    });
   });
 });


### PR DESCRIPTION
Our version of Capturama likely has a bug (https://bugs.webkit.org/show_bug.cgi?id=153662) that causes our data source image URLs to get double-encoded. 

The most direct way to reproduce is: 

```js
const url = new URL('https://www.movableink.com/something else.jpg');
const path = url.pathname;
const url2 = new URL('https://www.movableink.com');

url2.pathname = path;
  
console.log(url2.toString());
```

This should log: `https://www.movableink.com/something%20else.jpg`
Capturama Logs: `https://www.movableink.com/something%2520else.jpg`

The way to mitigate this issue is to decode the component parts of the URL as we set them: 

```js
const url = new URL('https://www.movableink.com/something else.jpg');
const path = decodeURI(url.pathname);
const url2 = new URL('https://www.movableink.com');

url2.pathname = path;
  
console.log(url2.toString());
```

Now, capturama correctly logs: `https://www.movableink.com/something%20else.jpg`